### PR TITLE
refactor(fontweight): allow unknown fontweight value

### DIFF
--- a/src/font.rs
+++ b/src/font.rs
@@ -50,7 +50,7 @@ impl Font {
 
     pub fn weight(&self) -> FontWeight {
         unsafe {
-            mem::transmute::<u32, FontWeight>((*self.native.get()).GetWeight())
+            FontWeight::from_u32((*self.native.get()).GetWeight().0)
         }
     }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -7,28 +7,58 @@ use std::mem;
 use winapi::um::dwrite::{DWRITE_FONT_STYLE, DWRITE_FONT_WEIGHT, DWRITE_FONT_STRETCH};
 
 // mirrors DWRITE_FONT_WEIGHT
-#[repr(u32)]
 #[derive(Deserialize, Serialize, PartialEq, Debug, Clone, Copy)]
 pub enum FontWeight {
-    Thin = 100,
-    ExtraLight = 200,
-    Light = 300,
-    SemiLight = 350,
-    Regular = 400,
-    Medium = 500,
-    SemiBold = 600,
-    Bold = 700,
-    ExtraBold = 800,
-    Black = 900,
-    ExtraBlack = 950,
+    Thin,
+    ExtraLight,
+    Light,
+    SemiLight,
+    Regular,
+    Medium,
+    SemiBold,
+    Bold,
+    ExtraBold,
+    Black,
+    ExtraBlack,
+    Unknown(u32)
 }
 
 impl FontWeight {
-    fn t(&self) -> DWRITE_FONT_WEIGHT {
-        unsafe { mem::transmute::<FontWeight, DWRITE_FONT_WEIGHT>(*self) }
+    fn t(&self) -> winapi::DWRITE_FONT_WEIGHT {
+        unsafe { mem::transmute::<u32, winapi::DWRITE_FONT_WEIGHT>(self.to_u32()) }
     }
-    pub fn to_u32(&self) -> u32 { unsafe { mem::transmute::<FontWeight, u32>(*self) } }
-    pub fn from_u32(v: u32) -> FontWeight { unsafe { mem::transmute::<u32, FontWeight>(v) } }
+    pub fn to_u32(&self) -> u32 {
+        match self {
+            FontWeight::Thin=> 100,
+            FontWeight::ExtraLight=> 200,
+            FontWeight::Light=> 300,
+            FontWeight::SemiLight=> 350,
+            FontWeight::Regular=> 400,
+            FontWeight::Medium=> 500,
+            FontWeight::SemiBold=> 600,
+            FontWeight::Bold=> 700,
+            FontWeight::ExtraBold=> 800,
+            FontWeight::Black=> 900,
+            FontWeight::ExtraBlack=> 950,
+            FontWeight::Unknown(v) => *v as u32
+        }
+    }
+    pub fn from_u32(v: u32) -> FontWeight {
+        match v {
+                100 => FontWeight::Thin,
+                200 => FontWeight::ExtraLight,
+                300 => FontWeight::Light,
+                350 => FontWeight::SemiLight,
+                400 => FontWeight::Regular,
+                500 => FontWeight::Medium,
+                600 => FontWeight::SemiBold,
+                700 => FontWeight::Bold,
+                800 => FontWeight::ExtraBold,
+                900 => FontWeight::Black,
+                950 => FontWeight::ExtraBlack,
+                _ => FontWeight::Unknown(v)
+            }
+    }
 }
 
 // mirrors DWRITE_FONT_STRETCH


### PR DESCRIPTION
Related with https://github.com/servo/servo/issues/21076.

Given reproducible code snippet
```
extern crate dwrote;
use dwrote::{FontCollection};

fn main() {
    let system_fc = FontCollection::system();

    if let Some(family) = system_fc.get_font_family_by_name("Microsoft YaHei") {
        let count = family.get_font_count();
        println!("fount count: {}", count);

        for i in 0..count {
            let font = family.get_font(i);
            {
                let descriptor = font.to_descriptor();

                let font = FontCollection::system().get_font_from_descriptor(&descriptor).unwrap();
                println!("reading [{}] {}: {}", i, font.family_name(), font.face_name());

                let style = font.style();
                let weight = font.weight();
                let stretch = font.stretch();
                if font.face_name().starts_with("Light") {
                    println!("\t read style: {:?}, stretch: {:?}", style, stretch);
                    //println!("{:?}", weight); //This will blow up
                } else {
                    println!("\t read style: {:?}, weight: {:?}, stretch: {:?}", style, weight, stretch);
                }

            }
        }
    }
}
```

When try to read weight from `Microsoft Yahei`, only on `Light` weight will throw exception. surprisingly while `DWRITE_FONT_WEIGHT` enum doesn't specify it in documented list `Yahei`'s light fontweight is not `300`:

![image](https://user-images.githubusercontent.com/1210596/42143345-738e3a52-7d69-11e8-86c8-13871d584b18.png)

but having adjusted value of `290` and enum conversion fails since there isn't matching value.

This PR refactors `FontWeight` enum to not use discriminator values, and add `FontWeight::Unknown(u32)` type to allow fallback if C enum contains non-matching values to enum values. There are couple of way I tried, but wasn't entirely sure around each approaches - except require manual matching from u32 value to enum and vice versa, this approach provides simplest way to resolve issue. 

1. DWRITE_FONT_WEIGHT enum doesn't have huge values, manual matching doesn't require lot of boilerplate
2. Potentially those enum value won't change quite frequently, also `Unknown(u32)` will provide fallback even if it occurs

Still, technically this can be breaking change if any consumer uses direct casting to u32 of enum values instead of using `to_u32()` interface: but so far I know there doesn't seem way to create non-breaking change if we'd like to have fallback values.

Note: this doesn't resolve servo side crash immediately - servo need to implement to handle fallback values.