### PR TITLE
Add a binding to `IDWriteFactory::CreateFontFileReference`.

### DIFF
--- a/src/comptr.rs
+++ b/src/comptr.rs
@@ -74,6 +74,10 @@ impl<T> ComPtr<T> {
         self.ptr = ptr::null_mut();
         ptr
     }
+
+    pub fn is_null(&self) -> bool {
+        self.ptr.is_null()
+    }
 }
 
 impl<T> Clone for ComPtr<T> {


### PR DESCRIPTION
This is needed to load fonts from local files efficiently.

r? @mbrubeck