### PR TITLE
Make serde optional, enabled by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,9 +9,13 @@ authors = ["Vladimir Vukicevic <vladimir@pobox.com>"]
 [lib]
 name = "dwrote"
 
+[features]
+default = ["serde_serialization"]
+serde_serialization = ["serde", "serde_derive"]
+
 [dependencies]
 libc = "0.2"
 lazy_static = "1"
 winapi = { version = "0.3.6", features = ["dwrite", "dwrite_1", "dwrite_3", "winnt", "unknwnbase", "libloaderapi", "winnls"] }
-serde = "1.0"
-serde_derive = "1.0"
+serde = { version = "1.0", optional = true }
+serde_derive = { version = "1.0", optional = true }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -118,4 +118,5 @@ build: false
 #directly or perform other testing commands. Rust will automatically be placed in the PATH
 # environment variable.
 test_script:
+  - cargo check --no-default-features
   - cargo test --verbose %cargoflags%

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,15 +4,17 @@
 
 #![allow(non_upper_case_globals)]
 
-#[macro_use]
+#[cfg_attr(feature = "serde_serialization", macro_use)]
+#[cfg(feature = "serde_serialization")]
 extern crate serde_derive;
+#[cfg(feature = "serde_serialization")]
+extern crate serde;
 
 #[macro_use]
 extern crate lazy_static;
 #[macro_use(DEFINE_GUID)]
 extern crate winapi;
 extern crate libc;
-extern crate serde;
 
 include!("types.rs");
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -7,7 +7,8 @@ use std::mem;
 use winapi::um::dwrite::{DWRITE_FONT_STYLE, DWRITE_FONT_WEIGHT, DWRITE_FONT_STRETCH};
 
 // mirrors DWRITE_FONT_WEIGHT
-#[derive(Deserialize, Serialize, PartialEq, Debug, Clone, Copy)]
+#[cfg_attr(feature = "serde_serialization", derive(Deserialize, Serialize))]
+#[derive(PartialEq, Debug, Clone, Copy)]
 pub enum FontWeight {
     Thin,
     ExtraLight,
@@ -63,7 +64,8 @@ impl FontWeight {
 
 // mirrors DWRITE_FONT_STRETCH
 #[repr(u32)]
-#[derive(Deserialize, Serialize, PartialEq, Debug, Clone, Copy)]
+#[cfg_attr(feature = "serde_serialization", derive(Deserialize, Serialize))]
+#[derive(PartialEq, Debug, Clone, Copy)]
 pub enum FontStretch {
     Undefined = 0,
     UltraCondensed = 1,
@@ -87,7 +89,8 @@ impl FontStretch {
 
 // mirrors DWRITE_FONT_STYLE
 #[repr(u32)]
-#[derive(Deserialize, Serialize, PartialEq, Debug, Clone, Copy)]
+#[cfg_attr(feature = "serde_serialization", derive(Deserialize, Serialize))]
+#[derive(PartialEq, Debug, Clone, Copy)]
 pub enum FontStyle {
     Normal = 0,
     Oblique = 1,
@@ -113,7 +116,8 @@ pub enum FontSimulations {
         winapi::um::dwrite::DWRITE_FONT_SIMULATIONS_OBLIQUE,
 }
 
-#[derive(Deserialize, Serialize, PartialEq, Debug, Clone)]
+#[cfg_attr(feature = "serde_serialization", derive(Deserialize, Serialize))]
+#[derive(PartialEq, Debug, Clone)]
 pub struct FontDescriptor {
     pub family_name: String,
     pub weight: FontWeight,


### PR DESCRIPTION
Not everyone who wants to use dwrote-rs may want to use serde. This PR makes serde support optional, but enabled by default for backwards compatibility.

Note that someone could have had `dwrote { version = "*", default-features = false }`, so technically this breaks semver. If this is merged, please release a new version on crates.io if possible. Thanks.