### PR TITLE
ensure FontFileStream is cleaned up with its owning FontFile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "dwrote"
 description = "Lightweight binding to DirectWrite."
 repository = "https://github.com/servo/dwrote-rs"
 license = "MPL-2.0"
-version = "0.5.1"
+version = "0.5.2"
 authors = ["Vladimir Vukicevic <vladimir@pobox.com>"]
 
 [lib]

--- a/src/com_helpers.rs
+++ b/src/com_helpers.rs
@@ -29,7 +29,6 @@ macro_rules! implement_iunknown {
                         return $crate::winapi::shared::winerror::E_NOINTERFACE;
                     };
 
-                    (*This).AddRef();
                     *ppvObject = this;
                     return S_OK;
                 }
@@ -70,7 +69,6 @@ macro_rules! implement_iunknown {
                         return $crate::winapi::shared::winerror::E_NOINTERFACE;
                     };
 
-                    (*This).AddRef();
                     *ppvObject = this;
                     return S_OK;
                 }

--- a/src/font_file_loader_impl.rs
+++ b/src/font_file_loader_impl.rs
@@ -3,7 +3,7 @@
 use std::{mem, ptr};
 use std::collections::HashMap;
 use std::sync::atomic::AtomicUsize;
-use std::sync::{Mutex, atomic};
+use std::sync::{Arc, Mutex, atomic};
 use std::marker::Send;
 use winapi::ctypes::c_void;
 use winapi::shared::basetsd::{UINT32, UINT64};
@@ -39,13 +39,13 @@ const FontFileLoaderVtbl: &'static IDWriteFontFileLoaderVtbl = &IDWriteFontFileL
             }
             assert!(fontFileReferenceKeySize == mem::size_of::<usize>() as UINT32);
             let key = *(fontFileReferenceKey as *const usize);
-            let stream = match FONT_FILE_STREAM_MAP.lock().unwrap().get_mut(&key) {
+            let stream = match FONT_FILE_STREAM_MAP.lock().unwrap().get(&key) {
                 None => {
                     *fontFileStream = ptr::null_mut();
                     return E_FAIL
                 }
-                Some(file_stream) => {
-                    file_stream.as_ptr()
+                Some(&FontFileStreamPtr(file_stream)) => {
+                    file_stream
                 }
             };
 
@@ -80,7 +80,8 @@ unsafe impl Sync for FontFileLoader {}
 
 struct FontFileStream {
     refcount: atomic::AtomicUsize,
-    data: Vec<u8>,
+    key: usize,
+    data: Arc<Vec<u8>>,
 }
 
 const FontFileStreamVtbl: &'static IDWriteFontFileStreamVtbl = &IDWriteFontFileStreamVtbl {
@@ -99,7 +100,7 @@ const FontFileStreamVtbl: &'static IDWriteFontFileStreamVtbl = &IDWriteFontFileS
                 return E_INVALIDARG
             }
             let index = fileOffset as usize;
-            *fragmentStart = this.data[index..].as_mut_ptr() as *const c_void;
+            *fragmentStart = this.data[index..].as_ptr() as *const c_void;
             S_OK
         }
         ReadFileFragment
@@ -135,11 +136,18 @@ const FontFileStreamVtbl: &'static IDWriteFontFileStreamVtbl = &IDWriteFontFileS
 };
 
 impl FontFileStream {
-    pub fn new(data: &[u8]) -> FontFileStream {
+    pub fn new(key: usize, data: Arc<Vec<u8>>) -> FontFileStream {
         FontFileStream {
             refcount: AtomicUsize::new(1),
-            data: data.to_vec(),
+            key,
+            data,
         }
+    }
+}
+
+impl Drop for FontFileStream {
+    fn drop(&mut self) {
+        DataFontHelper::unregister_font_data(self.key);
     }
 }
 
@@ -153,10 +161,14 @@ impl Com<IUnknown> for FontFileStream {
     fn vtbl() -> &'static IUnknownVtbl { &FontFileStreamVtbl.parent }
 }
 
+struct FontFileStreamPtr(*mut IDWriteFontFileStream);
+
+unsafe impl Send for FontFileStreamPtr {}
+
 static mut FONT_FILE_KEY: atomic::AtomicUsize = atomic::ATOMIC_USIZE_INIT;
 
 lazy_static! {
-    static ref FONT_FILE_STREAM_MAP: Mutex<HashMap<usize, ComPtr<IDWriteFontFileStream>>> = {
+    static ref FONT_FILE_STREAM_MAP: Mutex<HashMap<usize, FontFileStreamPtr>> = {
         Mutex::new(HashMap::new())
     };
 
@@ -174,16 +186,17 @@ lazy_static! {
 pub struct DataFontHelper;
 
 impl DataFontHelper {
-    pub fn register_font_data(font_data: &[u8]) -> (ComPtr<IDWriteFontFile>, usize) {
+    pub fn register_font_data(font_data: Arc<Vec<u8>>)
+        -> (ComPtr<IDWriteFontFile>, ComPtr<IDWriteFontFileStream>, usize) {
         unsafe {
             let key = FONT_FILE_KEY.fetch_add(1, atomic::Ordering::Relaxed);
-            let font_file_stream_native = FontFileStream::new(font_data);
+            let font_file_stream_native = FontFileStream::new(key, font_data);
             let font_file_stream: ComPtr<IDWriteFontFileStream> =
-                ComPtr::from_ptr(font_file_stream_native.into_interface());
+                ComPtr::already_addrefed(font_file_stream_native.into_interface());
 
             {
                 let mut map = FONT_FILE_STREAM_MAP.lock().unwrap();
-                map.insert(key, font_file_stream);
+                map.insert(key, FontFileStreamPtr(font_file_stream.as_ptr()));
             }
 
             let mut font_file: ComPtr<IDWriteFontFile> = ComPtr::new();
@@ -197,11 +210,11 @@ impl DataFontHelper {
                 assert!(hr == S_OK);
             }
 
-            (font_file, key)
+            (font_file, font_file_stream, key)
         }
     }
 
-    pub fn unregister_font_data(key: usize) {
+    fn unregister_font_data(key: usize) {
         let mut map = FONT_FILE_STREAM_MAP.lock().unwrap();
         if map.remove(&key).is_none() {
             panic!("unregister_font_data: trying to unregister key that is no longer registered");

--- a/src/test.rs
+++ b/src/test.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use super::*;
+use std::sync::Arc;
 
 #[test]
 fn test_system_family_iter() {
@@ -79,7 +80,7 @@ fn test_create_font_file_from_bytes() {
     assert!(bytes.len() > 0);
 
     // now go back
-    let new_font = FontFile::new_from_data(&bytes);
+    let new_font = FontFile::new_from_data(Arc::new(bytes));
     assert!(new_font.is_some());
 
     let new_font = new_font.unwrap();


### PR DESCRIPTION
When FontFile::new_from_data is used, a FontFileStream is created and placed in a global HashMap that is never cleaned up. We only want the FontFileStream to live as long as the FontFile itself does.

Further, the API passes in a data slice to FontFile::new_from_data which is copied into FontFileStream, contributing to memory bloat. This modifies the API to use an Arc instead, so that the data can be properly shared. 