### PR TITLE
restore missing AddRefs in QueryInterface

### DIFF
--- a/src/com_helpers.rs
+++ b/src/com_helpers.rs
@@ -29,6 +29,7 @@ macro_rules! implement_iunknown {
                         return $crate::winapi::shared::winerror::E_NOINTERFACE;
                     };
 
+                    (*This).AddRef();
                     *ppvObject = this;
                     return S_OK;
                 }
@@ -69,6 +70,7 @@ macro_rules! implement_iunknown {
                         return $crate::winapi::shared::winerror::E_NOINTERFACE;
                     };
 
+                    (*This).AddRef();
                     *ppvObject = this;
                     return S_OK;
                 }


### PR DESCRIPTION
An AddRef is generally necessary in QueryInterface, as the caller is supposed to Release after they are done with the result.