### PR TITLE
Bump up to 0.6.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "dwrote"
 description = "Lightweight binding to DirectWrite."
 repository = "https://github.com/servo/dwrote-rs"
 license = "MPL-2.0"
-version = "0.5.2"
+version = "0.6.0"
 authors = ["Vladimir Vukicevic <vladimir@pobox.com>"]
 
 [lib]


### PR DESCRIPTION
Update the crate to 0.6 so that the breaking changes introduced by 0.5.2 can be cancelled and applied to 0.6.0 instead.