### PR TITLE
fix get_recommended_rendering_mode error check

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "dwrote"
 description = "Lightweight binding to DirectWrite."
 repository = "https://github.com/servo/dwrote-rs"
 license = "MPL-2.0"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["Vladimir Vukicevic <vladimir@pobox.com>"]
 
 [lib]

--- a/src/font_face.rs
+++ b/src/font_face.rs
@@ -194,7 +194,7 @@ impl FontFace {
                                                                   rendering_params,
                                                                   &mut render_mode);
 
-        if !(hr != 0) {
+        if hr != 0 {
           return DWRITE_RENDERING_MODE_NATURAL_SYMMETRIC;
         }
 


### PR DESCRIPTION
This fixes downstream Gecko bug https://bugzilla.mozilla.org/show_bug.cgi?id=1505459

The error check in get_recommended_rendering_mode is incorrectly inverted, so every time this call actually succeeded, it would only return the default of natural-symmetric, regardless of what the render mode really should have been.