### PR TITLE
add FontCollection::get_system for more control over updating

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "dwrote"
 description = "Lightweight binding to DirectWrite."
 repository = "https://github.com/servo/dwrote-rs"
 license = "MPL-2.0"
-version = "0.6.1"
+version = "0.6.2"
 authors = ["Vladimir Vukicevic <vladimir@pobox.com>"]
 
 [lib]

--- a/src/font_collection.rs
+++ b/src/font_collection.rs
@@ -5,7 +5,7 @@
 use comptr::ComPtr;
 use winapi::um::dwrite::{IDWriteFontFamily, IDWriteFont, IDWriteFontCollection};
 use winapi::um::dwrite::{IDWriteFontCollectionLoader};
-use winapi::shared::minwindef::{BOOL, FALSE};
+use winapi::shared::minwindef::{BOOL, FALSE, TRUE};
 use winapi::shared::winerror::S_OK;
 use std::cell::UnsafeCell;
 use std::mem;
@@ -47,16 +47,23 @@ pub struct FontCollection {
 }
 
 impl FontCollection {
-    pub fn system() -> FontCollection {
+    pub fn get_system(update: bool) -> FontCollection {
         unsafe {
             let mut native: ComPtr<IDWriteFontCollection> = ComPtr::new();
-            let hr = (*DWriteFactory()).GetSystemFontCollection(native.getter_addrefs(), FALSE);
+            let hr = (*DWriteFactory()).GetSystemFontCollection(
+                native.getter_addrefs(),
+                if update { TRUE } else { FALSE },
+            );
             assert!(hr == 0);
 
             FontCollection {
                 native: UnsafeCell::new(native)
             }
         }
+    }
+
+    pub fn system() -> FontCollection {
+        FontCollection::get_system(false)
     }
 
     pub fn take(native: ComPtr<IDWriteFontCollection>) -> FontCollection {


### PR DESCRIPTION
This is to help resolve Gecko bug https://bugzilla.mozilla.org/show_bug.cgi?id=1455848

I need to be able to force the system font collection to update immediately in the event a font family is not found.