### PR TITLE
make RECT public

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "dwrote"
 description = "Lightweight binding to DirectWrite."
 repository = "https://github.com/servo/dwrote-rs"
 license = "MPL-2.0"
-version = "0.6.2"
+version = "0.6.3"
 authors = ["Vladimir Vukicevic <vladimir@pobox.com>"]
 
 [lib]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,6 +65,7 @@ pub use winapi::um::dwrite::{DWRITE_RENDERING_MODE};
 pub use winapi::um::dwrite::{DWRITE_TEXTURE_TYPE};
 pub use winapi::um::dwrite_3::{DWRITE_FONT_AXIS_VALUE};
 pub use winapi::um::dcommon::{DWRITE_MEASURING_MODE};
+pub use winapi::shared::windef::RECT;
 use winapi::um::libloaderapi::{GetProcAddress, LoadLibraryW};
 
 #[macro_use] mod com_helpers;


### PR DESCRIPTION
Currently glyph_run_analysis both takes and returns RECTs for several functions, but this type is not exported at all, which makes it difficult to manipulate. The only workaround is to currently import the winapi crate into a project, which is awkward just to retrieve a single type. It is much easier to just re-export the RECT type with dwrote so downstream use does not require an extra dep on winapi.