### PR TITLE
make FontFile::new_from_path analyze the font

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "dwrote"
 description = "Lightweight binding to DirectWrite."
 repository = "https://github.com/servo/dwrote-rs"
 license = "MPL-2.0"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Vladimir Vukicevic <vladimir@pobox.com>"]
 
 [lib]


### PR DESCRIPTION
This is necessary to resolve Firefox bug https://bugzilla.mozilla.org/show_bug.cgi?id=1455848

We need to switch over to using paths instead of descriptors, but FontFile::new_from_path does not call analyze() such that create_face() will always fail. This fixes that.