### PR TITLE
Add FontFallback and TextAnalysisSource objects

### DIFF
--- a/src/font_fallback.rs
+++ b/src/font_fallback.rs
@@ -1,0 +1,80 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use std::cell::UnsafeCell;
+use std::ptr::null_mut;
+
+use winapi::um::dwrite_2::IDWriteFontFallback;
+
+use super::*;
+use helpers::*;
+
+pub struct FontFallback {
+    native: UnsafeCell<ComPtr<IDWriteFontFallback>>,
+}
+
+pub struct FallbackResult {
+    /// Length of mapped substring, in utf-16 code units.
+    pub mapped_length: usize,
+    /// The font that should be used to render the substring.
+    pub mapped_font: Option<Font>,
+    /// The scale factor to apply.
+    pub scale: f32,
+}
+
+impl FontFallback {
+    pub fn take(native: ComPtr<IDWriteFontFallback>) -> FontFallback {
+        FontFallback {
+            native: UnsafeCell::new(native),
+        }
+    }
+
+    // TODO: I'm following crate conventions for unsafe, but it's bullshit
+    pub unsafe fn as_ptr(&self) -> *mut IDWriteFontFallback {
+        (*self.native.get()).as_ptr()
+    }
+
+    // TODO: map_characters (main function)
+    pub fn map_characters(
+            &self,
+            text_analysis_source: &TextAnalysisSource,
+            text_position: u32,
+            text_length: u32,
+            base_font: &FontCollection,
+            base_family: Option<&str>,
+            base_weight: FontWeight,
+            base_style: FontStyle,
+            base_stretch: FontStretch)
+            -> FallbackResult {
+        unsafe {
+            let mut font = null_mut();
+            let mut mapped_length = 0;
+            let mut scale = 0.0;
+            let hr = (*self.as_ptr()).MapCharacters(
+                text_analysis_source.as_ptr(),
+                text_position,
+                text_length,
+                base_font.as_ptr(),
+                base_family.map(|s| s.to_wide_null().as_mut_ptr()).unwrap_or(null_mut()),
+                base_weight.t(),
+                base_style.t(),
+                base_stretch.t(),
+                &mut mapped_length,
+                &mut font,
+                &mut scale,
+            );
+            assert!(hr == 0);
+            let mapped_font = if font.is_null() {
+                None
+            } else {
+                Some(Font::take(ComPtr::already_addrefed(font)))
+            };
+            FallbackResult {
+                mapped_length: mapped_length as usize,
+                mapped_font,
+                scale
+            }
+        }
+    }
+}

--- a/src/font_fallback.rs
+++ b/src/font_fallback.rs
@@ -32,7 +32,7 @@ impl FontFallback {
             let factory2 = factory2?;
             let mut native = null_mut();
             let hr = factory2.GetSystemFontFallback(&mut native);
-            assert!(hr == 0);
+            assert_eq!(hr, 0);
             Some(Self::take(ComPtr::from_ptr(native)))
         }
     }
@@ -77,7 +77,7 @@ impl FontFallback {
                 &mut font,
                 &mut scale,
             );
-            assert!(hr == 0);
+            assert_eq!(hr, 0);
             let mapped_font = if font.is_null() {
                 None
             } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,7 +97,7 @@ mod font_collection_impl; pub use font_collection_impl::CustomFontCollectionLoad
 // This is an implementation of `TextAnalysisSource` for client code.
 mod text_analysis_source_impl;
 pub use text_analysis_source_impl::{CustomTextAnalysisSourceImpl, NumberSubstitution,
-  TextAnalysisSourceImpl
+  TextAnalysisSourceMethods
 };
 
 // This is an internal implementation of `GeometrySink` so that we can

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,7 +77,7 @@ mod bitmap_render_target; pub use bitmap_render_target::BitmapRenderTarget;
 mod font; pub use font::{Font, InformationalStringId};
 mod font_collection; pub use font_collection::FontCollection;
 mod font_face; pub use font_face::{FontFace, FontFaceType};
-mod font_fallback; pub use font_fallback::FontFallback;
+mod font_fallback; pub use font_fallback::{FallbackResult, FontFallback};
 mod font_family; pub use font_family::FontFamily;
 mod font_file; pub use font_file::FontFile;
 mod gdi_interop; pub use gdi_interop::GdiInterop;
@@ -95,7 +95,10 @@ mod font_file_loader_impl;
 mod font_collection_impl; pub use font_collection_impl::CustomFontCollectionLoaderImpl;
 
 // This is an implementation of `TextAnalysisSource` for client code.
-mod text_analysis_source_impl; pub use text_analysis_source_impl::CustomTextAnalysisSourceImpl;
+mod text_analysis_source_impl;
+pub use text_analysis_source_impl::{CustomTextAnalysisSourceImpl, NumberSubstitution,
+  TextAnalysisSourceImpl
+};
 
 // This is an internal implementation of `GeometrySink` so that we can
 // expose `IDWriteGeometrySink` in an idiomatic way.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,11 +77,13 @@ mod bitmap_render_target; pub use bitmap_render_target::BitmapRenderTarget;
 mod font; pub use font::{Font, InformationalStringId};
 mod font_collection; pub use font_collection::FontCollection;
 mod font_face; pub use font_face::{FontFace, FontFaceType};
+mod font_fallback; pub use font_fallback::FontFallback;
 mod font_family; pub use font_family::FontFamily;
 mod font_file; pub use font_file::FontFile;
 mod gdi_interop; pub use gdi_interop::GdiInterop;
 mod outline_builder; pub use outline_builder::OutlineBuilder;
 mod rendering_params; pub use rendering_params::RenderingParams;
+mod text_analysis_source; pub use text_analysis_source::TextAnalysisSource;
 mod glyph_run_analysis; pub use glyph_run_analysis::GlyphRunAnalysis;
 
 // This is an internal implementation of FontFileLoader, for our utility
@@ -91,6 +93,9 @@ mod font_file_loader_impl;
 
 // This is an implementation of `FontCollectionLoader` for client code.
 mod font_collection_impl; pub use font_collection_impl::CustomFontCollectionLoaderImpl;
+
+// This is an implementation of `TextAnalysisSource` for client code.
+mod text_analysis_source_impl; pub use text_analysis_source_impl::CustomTextAnalysisSourceImpl;
 
 // This is an internal implementation of `GeometrySink` so that we can
 // expose `IDWriteGeometrySink` in an idiomatic way.

--- a/src/text_analysis_source.rs
+++ b/src/text_analysis_source.rs
@@ -4,7 +4,10 @@
 
 use std::cell::UnsafeCell;
 
+use winapi::ctypes::wchar_t;
 use winapi::um::dwrite::IDWriteTextAnalysisSource;
+
+use com_helpers::Com;
 
 use super::*;
 
@@ -13,7 +16,27 @@ pub struct TextAnalysisSource {
 }
 
 impl TextAnalysisSource {
+    /// Create a new custom TextAnalysisSource for the given text and a trait
+    /// implementation.
+    ///
+    /// Note: this method only supports a single `NumberSubstitution` for the
+    /// entire string.
+    pub fn new(inner: Box<dyn TextAnalysisSourceImpl>, text: Vec<wchar_t>,
+        number_subst: NumberSubstitution) -> TextAnalysisSource
+    {
+        let native = CustomTextAnalysisSourceImpl::new_native(inner, text, number_subst);
+        TextAnalysisSource::take(native)
+    }
+
     pub unsafe fn as_ptr(&self) -> *mut IDWriteTextAnalysisSource {
         (*self.native.get()).as_ptr()
     }
+
+    // TODO: following crate conventions, but there's a safety problem
+    pub fn take(native: ComPtr<IDWriteTextAnalysisSource>) -> TextAnalysisSource {
+        TextAnalysisSource {
+            native: UnsafeCell::new(native),
+        }
+    }
+
 }

--- a/src/text_analysis_source.rs
+++ b/src/text_analysis_source.rs
@@ -1,0 +1,19 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use std::cell::UnsafeCell;
+
+use winapi::um::dwrite::IDWriteTextAnalysisSource;
+
+use super::*;
+
+pub struct TextAnalysisSource {
+    native: UnsafeCell<ComPtr<IDWriteTextAnalysisSource>>,
+}
+
+impl TextAnalysisSource {
+    pub unsafe fn as_ptr(&self) -> *mut IDWriteTextAnalysisSource {
+        (*self.native.get()).as_ptr()
+    }
+}

--- a/src/text_analysis_source.rs
+++ b/src/text_analysis_source.rs
@@ -21,10 +21,12 @@ impl TextAnalysisSource {
     ///
     /// Note: this method only supports a single `NumberSubstitution` for the
     /// entire string.
-    pub fn new(inner: Box<dyn TextAnalysisSourceImpl>, text: Vec<wchar_t>,
-        number_subst: NumberSubstitution) -> TextAnalysisSource
+    pub fn from_text_and_number_subst(inner: Box<dyn TextAnalysisSourceMethods>,
+        text: Vec<wchar_t>, number_subst: NumberSubstitution) -> TextAnalysisSource
     {
-        let native = CustomTextAnalysisSourceImpl::new_native(inner, text, number_subst);
+        let native = CustomTextAnalysisSourceImpl::from_text_and_number_subst_native(
+            inner, text, number_subst
+        );
         TextAnalysisSource::take(native)
     }
 

--- a/src/text_analysis_source_impl.rs
+++ b/src/text_analysis_source_impl.rs
@@ -1,0 +1,203 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+//! A custom implementation of the "text analysis source" interface so that
+//! we can convey data to the `FontFallback::map_characters` method.
+
+#![allow(non_snake_case)]
+
+use std::borrow::Cow;
+use std::cell::UnsafeCell;
+use std::mem;
+use std::ptr::null;
+use std::sync::atomic::AtomicUsize;
+use winapi::ctypes::wchar_t;
+use winapi::shared::basetsd::UINT32;
+use winapi::shared::guiddef::REFIID;
+use winapi::shared::minwindef::{BOOL, FALSE, TRUE, ULONG};
+use winapi::shared::winerror::{E_INVALIDARG, S_OK};
+use winapi::um::dwrite::{DWRITE_NUMBER_SUBSTITUTION_METHOD, DWRITE_READING_DIRECTION,
+    IDWriteNumberSubstitution, IDWriteTextAnalysisSource, IDWriteTextAnalysisSourceVtbl,
+};
+use winapi::um::unknwnbase::{IUnknown, IUnknownVtbl};
+use winapi::um::winnt::HRESULT;
+
+use helpers::ToWide;
+use super::DWriteFactory;
+use com_helpers::{Com, UuidOfIUnknown};
+use comptr::ComPtr;
+
+/// The Rust side of a custom text analysis source implementation.
+pub trait TextAnalysisSourceImpl {
+    /// Determine the locale for a range of text.
+    ///
+    /// Return locale and length of text (in utf-16 code units) for which the
+    /// locale is valid.
+    fn get_locale_name<'a>(&'a self, text_position: u32) -> (Cow<'a, str>, u32);
+
+    /// Get the text direction for the paragraph.
+    fn get_paragraph_reading_direction(&self) -> DWRITE_READING_DIRECTION;
+}
+
+pub struct CustomTextAnalysisSourceImpl {
+    refcount: AtomicUsize,
+    inner: Box<dyn TextAnalysisSourceImpl>,
+    text: Vec<wchar_t>,
+    number_subst: NumberSubstitution,
+    locale_buf: Vec<wchar_t>,
+}
+
+/// A wrapped version of an `IDWriteNumberSubstitution` object.
+pub struct NumberSubstitution {
+    native: UnsafeCell<ComPtr<IDWriteNumberSubstitution>>,
+}
+
+// TODO: implement Clone, for convenience and efficiency?
+
+DEFINE_GUID! {
+    DWRITE_TEXT_ANALYSIS_SOURCE_UUID,
+    0x12345678, 0x1234, 0x5678, 0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc, 0xde, 0xf0
+}
+
+static TEXT_ANALYSIS_SOURCE_VTBL: IDWriteTextAnalysisSourceVtbl =
+        IDWriteTextAnalysisSourceVtbl {
+    parent: implement_iunknown!(static IDWriteTextAnalysisSource,
+                                DWRITE_TEXT_ANALYSIS_SOURCE_UUID,
+                                CustomTextAnalysisSourceImpl),
+    GetLocaleName: CustomTextAnalysisSourceImpl_GetLocaleName,
+    GetNumberSubstitution: CustomTextAnalysisSourceImpl_GetNumberSubstitution,
+    GetParagraphReadingDirection: CustomTextAnalysisSourceImpl_GetParagraphReadingDirection,
+    GetTextAtPosition: CustomTextAnalysisSourceImpl_GetTextAtPosition,
+    GetTextBeforePosition: CustomTextAnalysisSourceImpl_GetTextBeforePosition,
+};
+
+impl CustomTextAnalysisSourceImpl {
+    /// Create a new custom TextAnalysisSource for the given text and a trait
+    /// implementation.
+    ///
+    /// Note: this method only supports a single `NumberSubstitution` for the
+    /// entire string.
+    fn new(inner: Box<dyn TextAnalysisSourceImpl>, text: Vec<wchar_t>,
+        number_subst: NumberSubstitution) -> ComPtr<IDWriteTextAnalysisSource>
+    {
+        assert!(text.len() <= (std::u32::MAX as usize));
+        unsafe {
+            ComPtr::already_addrefed(CustomTextAnalysisSourceImpl {
+                refcount: AtomicUsize::new(1),
+                inner,
+                text,
+                number_subst,
+                locale_buf: Vec::new(),
+            }.into_interface())
+        }
+    }
+}
+
+impl Com<IDWriteTextAnalysisSource> for CustomTextAnalysisSourceImpl {
+    type Vtbl = IDWriteTextAnalysisSourceVtbl;
+    #[inline]
+    fn vtbl() -> &'static IDWriteTextAnalysisSourceVtbl {
+        &TEXT_ANALYSIS_SOURCE_VTBL
+    }
+}
+
+impl Com<IUnknown> for CustomTextAnalysisSourceImpl {
+    type Vtbl = IUnknownVtbl;
+    #[inline]
+    fn vtbl() -> &'static IUnknownVtbl {
+        &TEXT_ANALYSIS_SOURCE_VTBL.parent
+    }
+}
+
+unsafe extern "system" fn CustomTextAnalysisSourceImpl_GetLocaleName(
+        this: *mut IDWriteTextAnalysisSource,
+        text_position: UINT32,
+        text_length: *mut UINT32,
+        locale_name: *mut *const wchar_t)
+        -> HRESULT {
+    let this = CustomTextAnalysisSourceImpl::from_interface(this);
+    let (locale, text_len) = this.inner.get_locale_name(text_position);
+    // TODO(performance): reuse buffer (and maybe use smallvec)
+    this.locale_buf = locale.as_ref().to_wide_null();
+    *text_length = text_len;
+    *locale_name = this.locale_buf.as_ptr();
+    S_OK
+}
+
+unsafe extern "system" fn CustomTextAnalysisSourceImpl_GetNumberSubstitution(
+        this: *mut IDWriteTextAnalysisSource,
+        text_position: UINT32,
+        text_length: *mut UINT32,
+        number_substitution: *mut *mut IDWriteNumberSubstitution)
+        -> HRESULT {
+    let this = CustomTextAnalysisSourceImpl::from_interface(this);
+    if text_position >= (this.text.len() as u32) {
+        return E_INVALIDARG;
+    }
+    (*this.number_subst.native.get()).addref();
+    *text_length = (this.text.len() as UINT32) - text_position;
+    *number_substitution = (*this.number_subst.native.get()).as_ptr();
+    S_OK
+}
+
+unsafe extern "system" fn CustomTextAnalysisSourceImpl_GetParagraphReadingDirection(
+        this: *mut IDWriteTextAnalysisSource)
+        -> DWRITE_READING_DIRECTION {
+    let this = CustomTextAnalysisSourceImpl::from_interface(this);
+    this.inner.get_paragraph_reading_direction()
+}
+
+unsafe extern "system" fn CustomTextAnalysisSourceImpl_GetTextAtPosition(
+        this: *mut IDWriteTextAnalysisSource,
+        text_position: UINT32,
+        text_string: *mut *const wchar_t,
+        text_length: *mut UINT32)
+        -> HRESULT {
+    let this = CustomTextAnalysisSourceImpl::from_interface(this);
+    if text_position >= (this.text.len() as u32) {
+        *text_string = null();
+        *text_length = 0;
+        return S_OK;
+    }
+    *text_string = this.text.as_ptr().add(text_position as usize);
+    *text_length = (this.text.len() as UINT32) - text_position;
+    S_OK
+}
+
+unsafe extern "system" fn CustomTextAnalysisSourceImpl_GetTextBeforePosition(
+        this: *mut IDWriteTextAnalysisSource,
+        text_position: UINT32,
+        text_string: *mut *const wchar_t,
+        text_length: *mut UINT32)
+        -> HRESULT {
+    let this = CustomTextAnalysisSourceImpl::from_interface(this);
+    if text_position == 0 || text_position > (this.text.len() as u32) {
+        *text_string = null();
+        *text_length = 0;
+        return S_OK;
+    }
+    *text_string = this.text.as_ptr();
+    *text_length = text_position;
+    S_OK
+}
+
+impl NumberSubstitution {
+    pub fn new(subst_method: DWRITE_NUMBER_SUBSTITUTION_METHOD, locale: &str,
+        ignore_user_overrides: bool) -> NumberSubstitution
+    {
+        unsafe {
+            let mut native: ComPtr<IDWriteNumberSubstitution> = ComPtr::new();
+            let hr = (*DWriteFactory()).CreateNumberSubstitution(
+                subst_method,
+                locale.to_wide_null().as_ptr(),
+                if ignore_user_overrides { TRUE } else { FALSE },
+                native.getter_addrefs(),
+            );
+            assert!(hr == 0, "error creating number substitution");
+            NumberSubstitution {
+                native: UnsafeCell::new(native)
+            }
+        }
+    }
+}

--- a/src/text_analysis_source_impl.rs
+++ b/src/text_analysis_source_impl.rs
@@ -29,7 +29,7 @@ use com_helpers::{Com, UuidOfIUnknown};
 use comptr::ComPtr;
 
 /// The Rust side of a custom text analysis source implementation.
-pub trait TextAnalysisSourceImpl {
+pub trait TextAnalysisSourceMethods {
     /// Determine the locale for a range of text.
     ///
     /// Return locale and length of text (in utf-16 code units) for which the
@@ -42,7 +42,7 @@ pub trait TextAnalysisSourceImpl {
 
 pub struct CustomTextAnalysisSourceImpl {
     refcount: AtomicUsize,
-    inner: Box<dyn TextAnalysisSourceImpl>,
+    inner: Box<dyn TextAnalysisSourceMethods>,
     text: Vec<wchar_t>,
     number_subst: NumberSubstitution,
     locale_buf: Vec<wchar_t>,
@@ -78,8 +78,8 @@ impl CustomTextAnalysisSourceImpl {
     ///
     /// Note: this method only supports a single `NumberSubstitution` for the
     /// entire string.
-    pub fn new_native(inner: Box<dyn TextAnalysisSourceImpl>, text: Vec<wchar_t>,
-        number_subst: NumberSubstitution) -> ComPtr<IDWriteTextAnalysisSource>
+    pub fn from_text_and_number_subst_native(inner: Box<dyn TextAnalysisSourceMethods>,
+        text: Vec<wchar_t>, number_subst: NumberSubstitution) -> ComPtr<IDWriteTextAnalysisSource>
     {
         assert!(text.len() <= (std::u32::MAX as usize));
         unsafe {
@@ -194,7 +194,7 @@ impl NumberSubstitution {
                 if ignore_user_overrides { TRUE } else { FALSE },
                 native.getter_addrefs(),
             );
-            assert!(hr == 0, "error creating number substitution");
+            assert_eq!(hr, 0, "error creating number substitution");
             NumberSubstitution {
                 native: UnsafeCell::new(native)
             }

--- a/src/text_analysis_source_impl.rs
+++ b/src/text_analysis_source_impl.rs
@@ -78,7 +78,7 @@ impl CustomTextAnalysisSourceImpl {
     ///
     /// Note: this method only supports a single `NumberSubstitution` for the
     /// entire string.
-    fn new(inner: Box<dyn TextAnalysisSourceImpl>, text: Vec<wchar_t>,
+    pub fn new_native(inner: Box<dyn TextAnalysisSourceImpl>, text: Vec<wchar_t>,
         number_subst: NumberSubstitution) -> ComPtr<IDWriteTextAnalysisSource>
     {
         assert!(text.len() <= (std::u32::MAX as usize));


### PR DESCRIPTION
Adds wrapping for FontFallback and TextAnalysisSource, including custom implementations of the latter in Rust.