### PR TITLE
Return the `DWRITE_FONT_METRICS1` structure on Windows 8 and up.

### DIFF
--- a/src/font_face.rs
+++ b/src/font_face.rs
@@ -28,24 +28,21 @@ use winapi::um::dwrite::{DWRITE_GLYPH_OFFSET, DWRITE_MATRIX, DWRITE_RENDERING_MO
 use winapi::um::dwrite::{DWRITE_RENDERING_MODE_DEFAULT, DWRITE_RENDERING_MODE_NATURAL_SYMMETRIC};
 use winapi::um::dwrite::{IDWriteFontCollection, IDWriteFont, IDWriteFontFace, IDWriteFontFile};
 use winapi::um::dwrite::{IDWriteRenderingParams};
+use winapi::um::dwrite_1::IDWriteFontFace1;
 use winapi::um::dwrite_3::{IDWriteFontFace5, IDWriteFontResource, DWRITE_FONT_AXIS_VALUE};
 
 pub struct FontFace {
     native: UnsafeCell<ComPtr<IDWriteFontFace>>,
     face5: UnsafeCell<Option<ComPtr<IDWriteFontFace5>>>,
-    metrics: FontMetrics,
 }
 
 impl FontFace {
     pub fn take(native: ComPtr<IDWriteFontFace>) -> FontFace {
         unsafe {
-            let mut metrics: FontMetrics = zeroed();
             let cell = UnsafeCell::new(native);
-            (*cell.get()).GetMetrics(&mut metrics);
             FontFace {
                 native: cell,
                 face5: UnsafeCell::new(None),
-                metrics: metrics,
             }
         }
     }
@@ -101,15 +98,22 @@ impl FontFace {
         }
     }
 
-    pub fn metrics(&self) -> &FontMetrics {
-        &self.metrics
-    }
-
-    pub fn get_metrics(&self) -> FontMetrics {
+    pub fn metrics(&self) -> FontMetrics {
         unsafe {
-            let mut metrics: DWRITE_FONT_METRICS = zeroed();
-            (*self.native.get()).GetMetrics(&mut metrics);
-            metrics
+            let font_1: Option<ComPtr<IDWriteFontFace1>> =
+                (*self.native.get()).query_interface(&IDWriteFontFace1::uuidof());
+            match font_1 {
+                None => {
+                    let mut metrics = mem::zeroed();
+                    (*self.native.get()).GetMetrics(&mut metrics);
+                    FontMetrics::Metrics0(metrics)
+                }
+                Some(font_1) => {
+                    let mut metrics_1 = mem::zeroed();
+                    font_1.GetMetrics(&mut metrics_1);
+                    FontMetrics::Metrics1(metrics_1)
+                }
+            }
         }
     }
 
@@ -333,7 +337,6 @@ impl Clone for FontFace {
             FontFace {
                 native: UnsafeCell::new((*self.native.get()).clone()),
                 face5: UnsafeCell::new(None),
-                metrics: self.metrics,
             }
         }
     }

--- a/src/font_face.rs
+++ b/src/font_face.rs
@@ -154,6 +154,10 @@ impl FontFace {
         }
     }
 
+    /// Returns the contents of the OpenType table with the given tag.
+    ///
+    /// NB: The bytes of the tag are reversed! You probably want to use the `u32::swap_bytes()`
+    /// method on the tag value before calling this method.
     pub fn get_font_table(&self, opentype_table_tag: u32) -> Option<Vec<u8>> {
         unsafe {
             let mut table_data_ptr: *const u8 = ptr::null_mut();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,7 +42,8 @@ mod test;
 
 // We still use the DWrite structs for things like metrics; re-export them
 // here
-pub use winapi::um::dwrite::DWRITE_FONT_METRICS as FontMetrics;
+pub use winapi::um::dwrite::DWRITE_FONT_METRICS as FontMetrics0;
+pub use winapi::um::dwrite_1::DWRITE_FONT_METRICS1 as FontMetrics1;
 pub use winapi::um::dwrite::DWRITE_GLYPH_OFFSET as GlyphOffset;
 pub use winapi::um::dwrite::{DWRITE_MATRIX, DWRITE_GLYPH_RUN};
 pub use winapi::um::dwrite::{DWRITE_RENDERING_MODE_DEFAULT,
@@ -74,7 +75,7 @@ use winapi::um::libloaderapi::{GetProcAddress, LoadLibraryW};
 #[macro_use] mod com_helpers;
 
 mod bitmap_render_target; pub use bitmap_render_target::BitmapRenderTarget;
-mod font; pub use font::{Font, InformationalStringId};
+mod font; pub use font::{Font, FontMetrics, InformationalStringId};
 mod font_collection; pub use font_collection::FontCollection;
 mod font_face; pub use font_face::{FontFace, FontFaceType};
 mod font_fallback; pub use font_fallback::{FallbackResult, FontFallback};

--- a/src/test.rs
+++ b/src/test.rs
@@ -97,14 +97,17 @@ fn test_glyph_image() {
     let face = arial_font.create_font_face();
     let a_index = face.get_glyph_indices(&['A' as u32])[0];
 
-    let metrics = face.get_metrics();
-
     let gm = face.get_design_glyph_metrics(&[a_index], false)[0];
 
     let device_pixel_ratio = 1.0f32;
     let em_size = 10.0f32;
 
-    let design_units_per_pixel = face.metrics().designUnitsPerEm as f32 / 16. as f32;
+    let design_units_per_em = match face.metrics() {
+        FontMetrics::Metrics0(ref metrics) => metrics.designUnitsPerEm,
+        FontMetrics::Metrics1(ref metrics) => metrics.designUnitsPerEm,
+    };
+    let design_units_per_pixel = design_units_per_em as f32 / 16.;
+
     let scaled_design_units_to_pixels = (em_size * device_pixel_ratio) / design_units_per_pixel;
 
     let width = (gm.advanceWidth as i32 - (gm.leftSideBearing + gm.rightSideBearing)) as f32 * scaled_design_units_to_pixels;


### PR DESCRIPTION
This is needed to return the global bounding box. See
servo/font-kit#29.

r? @jdm 