### PR TITLE
Make NumberSubst optional in TextAnalysisSource

### DIFF
--- a/src/text_analysis_source.rs
+++ b/src/text_analysis_source.rs
@@ -17,6 +17,19 @@ impl TextAnalysisSource {
     /// Create a new custom TextAnalysisSource for the given text and a trait
     /// implementation.
     ///
+    /// Note: this method has no NumberSubsitution specified. See
+    /// `from_text_and_number_subst` if you need number substitution.
+    pub fn from_text(
+        inner: Box<dyn TextAnalysisSourceMethods>,
+        text: Vec<wchar_t>,
+    ) -> TextAnalysisSource {
+        let native = CustomTextAnalysisSourceImpl::from_text_native(inner, text);
+        TextAnalysisSource::take(native)
+    }
+
+    /// Create a new custom TextAnalysisSource for the given text and a trait
+    /// implementation.
+    ///
     /// Note: this method only supports a single `NumberSubstitution` for the
     /// entire string.
     pub fn from_text_and_number_subst(


### PR DESCRIPTION
According to the [docs for IDWriteTextAnalysisSource](https://docs.microsoft.com/en-gb/windows/win32/api/dwrite/nn-dwrite-idwritetextanalysissource?redirectedfrom=MSDN) (and my own testing of this PR) it is fine for the `GetNumberSubstitution` method to just return `S_OK` and set the pointer to null if no number substitution is needed.

This simplifies downstream usage slightly for use cases which aren't concerned about number substitution (such as my own).

