### PR TITLE
Allow TextAnalysisSource to use borrowed data

### DIFF
--- a/src/text_analysis_source.rs
+++ b/src/text_analysis_source.rs
@@ -2,29 +2,36 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use std::cell::UnsafeCell;
+use std::borrow::Cow;
+use std::marker::PhantomData;
 use winapi::ctypes::wchar_t;
 use winapi::um::dwrite::IDWriteTextAnalysisSource;
 use wio::com::ComPtr;
 
 use super::*;
+use crate::com_helpers::Com;
 
-pub struct TextAnalysisSource {
-    native: UnsafeCell<ComPtr<IDWriteTextAnalysisSource>>,
+pub struct TextAnalysisSource<'a> {
+    native: ComPtr<IDWriteTextAnalysisSource>,
+    phantom: PhantomData<CustomTextAnalysisSourceImpl<'a>>
 }
 
-impl TextAnalysisSource {
+impl<'a> TextAnalysisSource<'a> {
     /// Create a new custom TextAnalysisSource for the given text and a trait
     /// implementation.
     ///
     /// Note: this method has no NumberSubsitution specified. See
     /// `from_text_and_number_subst` if you need number substitution.
     pub fn from_text(
-        inner: Box<dyn TextAnalysisSourceMethods>,
-        text: Vec<wchar_t>,
-    ) -> TextAnalysisSource {
-        let native = CustomTextAnalysisSourceImpl::from_text_native(inner, text);
-        TextAnalysisSource::take(native)
+        inner: Box<dyn TextAnalysisSourceMethods + 'a>,
+        text: Cow<'a, [wchar_t]>,
+    ) -> TextAnalysisSource<'a> {
+        let native = unsafe {
+            ComPtr::from_raw(
+                CustomTextAnalysisSourceImpl::from_text_native(inner, text).into_interface()
+            )
+        };
+        TextAnalysisSource { native, phantom: PhantomData }
     }
 
     /// Create a new custom TextAnalysisSource for the given text and a trait
@@ -33,26 +40,24 @@ impl TextAnalysisSource {
     /// Note: this method only supports a single `NumberSubstitution` for the
     /// entire string.
     pub fn from_text_and_number_subst(
-        inner: Box<dyn TextAnalysisSourceMethods>,
-        text: Vec<wchar_t>,
+        inner: Box<dyn TextAnalysisSourceMethods + 'a>,
+        text: Cow<'a, [wchar_t]>,
         number_subst: NumberSubstitution,
-    ) -> TextAnalysisSource {
-        let native = CustomTextAnalysisSourceImpl::from_text_and_number_subst_native(
-            inner,
-            text,
-            number_subst,
-        );
-        TextAnalysisSource::take(native)
+    ) -> TextAnalysisSource<'a> {
+        let native = unsafe {
+            ComPtr::from_raw(
+                CustomTextAnalysisSourceImpl::from_text_and_number_subst_native(
+                    inner,
+                    text,
+                    number_subst,
+                )
+                .into_interface()
+            )
+        };
+        TextAnalysisSource { native, phantom: PhantomData }
     }
 
-    pub unsafe fn as_ptr(&self) -> *mut IDWriteTextAnalysisSource {
-        (*self.native.get()).as_raw()
-    }
-
-    // TODO: following crate conventions, but there's a safety problem
-    pub fn take(native: ComPtr<IDWriteTextAnalysisSource>) -> TextAnalysisSource {
-        TextAnalysisSource {
-            native: UnsafeCell::new(native),
-        }
+    pub fn as_ptr(&self) -> *mut IDWriteTextAnalysisSource {
+        self.native.as_raw()
     }
 }


### PR DESCRIPTION
This adds a lifetime to `TextAnalysisSource`, which allows the `TextAnalysisSourceMethods` to contain borrowed data.

Additionally the `text` can then be a `Cow` rather than requiring to pass a copy of a `Vec`.

Just a small performance optimization.