### PR TITLE
Add null terminator to en-us locale string.

### DIFF
--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -19,7 +19,7 @@ lazy_static! {
             locale
         }
     };
-    static ref EN_US_LOCALE: Vec<wchar_t> = { OsStr::new("en-us").encode_wide().collect() };
+    static ref EN_US_LOCALE: Vec<wchar_t> = { OsStr::new("en-us").to_wide_null() };
 }
 
 pub fn get_locale_string(strings: &mut ComPtr<IDWriteLocalizedStrings>) -> String {


### PR DESCRIPTION
FindLocaleName expects a null-terminated array of characters.