### PR TITLE
Exchange Arc<Vec<u8>> for Arc<Cow<'a, [u8]>>

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "dwrote"
 description = "Lightweight binding to DirectWrite."
 repository = "https://github.com/servo/dwrote-rs"
 license = "MPL-2.0"
-version = "0.11.0"
+version = "0.12.0"
 authors = ["The Servo Project Developers", "Vladimir Vukicevic <vladimir@pobox.com>"]
 edition = "2018"
 

--- a/src/font_file.rs
+++ b/src/font_file.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use std::borrow::Cow;
 use std::cell::UnsafeCell;
 use std::ffi::OsString;
 use std::os::windows::ffi::{OsStrExt, OsStringExt};
@@ -63,7 +64,7 @@ impl FontFile {
         }
     }
 
-    pub fn new_from_data(data: Arc<Vec<u8>>) -> Option<FontFile> {
+    pub fn new_from_data(data: Arc<Cow<'static, [u8]>>) -> Option<FontFile> {
         let (font_file, font_file_stream, key) = DataFontHelper::register_font_data(data);
 
         let mut ff = FontFile {
@@ -80,7 +81,7 @@ impl FontFile {
         }
     }
 
-    pub fn analyze_data(data: Arc<Vec<u8>>) -> u32 {
+    pub fn analyze_data(data: Arc<Cow<'static, [u8]>>) -> u32 {
         let (font_file, font_file_stream, key) = DataFontHelper::register_font_data(data);
 
         let mut ff = FontFile {


### PR DESCRIPTION
This way users do not have to allocate the font if the font data is included in the binary. See https://github.com/servo/webrender/pull/4233