### PR TITLE
ci: Update actions.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,13 +12,10 @@ jobs:
     runs-on: windows-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Cargo build
         run: cargo build --no-default-features


### PR DESCRIPTION
Switch from `actions-rs/toolchain` to `dtolnay/rust-toolchain` as the former is not maintained.