### PR TITLE
Rename `master` branch to `main`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [auto]
+    branches: [main]
   pull_request:
   workflow_dispatch:
 


### PR DESCRIPTION
This change modifies the workflow to run on pushes to `main` branch instead of `auto` which was used by homu in the past.