### PR TITLE
Allow creating fonts with `Arc<dyn AsRef[u8] + Send + Sync>`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "dwrote"
 description = "Lightweight binding to DirectWrite."
 repository = "https://github.com/servo/dwrote-rs"
 license = "MPL-2.0"
-version = "0.11.1"
+version = "0.11.2"
 authors = ["The Servo Project Developers", "Vladimir Vukicevic <vladimir@pobox.com>"]
 edition = "2018"
 

--- a/src/font_file.rs
+++ b/src/font_file.rs
@@ -63,8 +63,13 @@ impl FontFile {
         }
     }
 
+    #[deprecated(since = "0.11.2", note = "please use `new_from_buffer` instead")]
     pub fn new_from_data(data: Arc<Vec<u8>>) -> Option<FontFile> {
-        let (font_file, font_file_stream, key) = DataFontHelper::register_font_data(data);
+        Self::new_from_buffer(data)
+    }
+
+    pub fn new_from_buffer(data: Arc<dyn AsRef<[u8]> + Sync + Send>) -> Option<FontFile> {
+        let (font_file, font_file_stream, key) = DataFontHelper::register_font_buffer(data);
 
         let mut ff = FontFile {
             native: UnsafeCell::new(font_file),
@@ -80,8 +85,13 @@ impl FontFile {
         }
     }
 
+    #[deprecated(since = "0.11.2", note = "please use `analyze_buffer` instead")]
     pub fn analyze_data(data: Arc<Vec<u8>>) -> u32 {
-        let (font_file, font_file_stream, key) = DataFontHelper::register_font_data(data);
+        Self::analyze_buffer(data)
+    }
+
+    pub fn analyze_buffer(buffer: Arc<dyn AsRef<[u8]> + Sync + Send>) -> u32 {
+        let (font_file, font_file_stream, key) = DataFontHelper::register_font_buffer(buffer);
 
         let mut ff = FontFile {
             native: UnsafeCell::new(font_file),

--- a/src/test.rs
+++ b/src/test.rs
@@ -92,7 +92,11 @@ fn test_create_font_file_from_bytes() {
     assert!(bytes.len() > 0);
 
     // now go back
-    let new_font = FontFile::new_from_data(Arc::new(bytes));
+    #[allow(deprecated)]
+    let new_font = FontFile::new_from_data(Arc::new(bytes.clone()));
+    assert!(new_font.is_some());
+
+    let new_font = FontFile::new_from_buffer(Arc::new(bytes));
     assert!(new_font.is_some());
 
     let _new_font = new_font.unwrap();


### PR DESCRIPTION
This has advantages over a simple `Arc<Vec<u8>>` because it can avoid
data copies. A common case that this happens is when Servo creates
fonts from shared memory. In addition, this maintains full compatability
with `Arc<Vec<u8>>` because it fulfills the trait.

Finally, this bumps the version so that the changes can be deployed.
