### PR TITLE
add analogous fallible font fetching methods

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ serde_serialization = ["serde", "serde_derive"]
 [dependencies]
 libc = "0.2"
 lazy_static = "1"
-winapi = { version = "0.3.6", features = ["dwrite", "dwrite_1", "dwrite_3", "winnt", "unknwnbase", "libloaderapi", "winnls", "winerror"] }
+winapi = { version = "0.3.6", features = ["dwrite", "dwrite_1", "dwrite_3", "winnt", "unknwnbase", "libloaderapi", "winnls"] }
 serde = { version = "1.0", optional = true }
 serde_derive = { version = "1.0", optional = true }
 wio = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ serde_serialization = ["serde", "serde_derive"]
 [dependencies]
 libc = "0.2"
 lazy_static = "1"
-winapi = { version = "0.3.6", features = ["dwrite", "dwrite_1", "dwrite_3", "winnt", "unknwnbase", "libloaderapi", "winnls"] }
+winapi = { version = "0.3.6", features = ["dwrite", "dwrite_1", "dwrite_3", "winnt", "unknwnbase", "libloaderapi", "winnls", "winerror"] }
 serde = { version = "1.0", optional = true }
 serde_derive = { version = "1.0", optional = true }
 wio = "0.2"

--- a/src/font_family.rs
+++ b/src/font_family.rs
@@ -26,11 +26,12 @@ impl FontFamily {
         (*self.native.get()).as_raw()
     }
 
+    #[deprecated(note = "Use `family_name` instead.")]
     pub fn name(&self) -> String {
-        self.try_name().unwrap()
+        self.family_name().unwrap()
     }
 
-    pub fn try_name(&self) -> Result<String, HRESULT> {
+    pub fn family_name(&self) -> Result<String, HRESULT> {
         let mut family_names: *mut IDWriteLocalizedStrings = ptr::null_mut();
         unsafe {
             let hr = (*self.native.get()).GetFamilyNames(&mut family_names);
@@ -41,17 +42,17 @@ impl FontFamily {
         }
     }
 
+    #[deprecated(note = "Use `first_matching_font` instead.")]
     pub fn get_first_matching_font(
         &self,
         weight: FontWeight,
         stretch: FontStretch,
         style: FontStyle,
     ) -> Font {
-        self.try_get_first_matching_font(weight, stretch, style)
-            .unwrap()
+        self.first_matching_font(weight, stretch, style).unwrap()
     }
 
-    pub fn try_get_first_matching_font(
+    pub fn first_matching_font(
         &self,
         weight: FontWeight,
         stretch: FontStretch,
@@ -72,11 +73,12 @@ impl FontFamily {
         }
     }
 
+    #[deprecated(note = "Use `font_collection` instead.")]
     pub fn get_font_collection(&self) -> FontCollection {
-        self.try_get_font_collection().unwrap()
+        self.font_collection().unwrap()
     }
 
-    pub fn try_get_font_collection(&self) -> Result<FontCollection, HRESULT> {
+    pub fn font_collection(&self) -> Result<FontCollection, HRESULT> {
         let mut collection: *mut IDWriteFontCollection = ptr::null_mut();
         unsafe {
             let hr = (*self.native.get()).GetFontCollection(&mut collection);
@@ -91,11 +93,12 @@ impl FontFamily {
         unsafe { (*self.native.get()).GetFontCount() }
     }
 
+    #[deprecated(note = "Use `font` instead.")]
     pub fn get_font(&self, index: u32) -> Font {
-        self.try_get_font(index).unwrap()
+        self.font(index).unwrap()
     }
 
-    pub fn try_get_font(&self, index: u32) -> Result<Font, HRESULT> {
+    pub fn font(&self, index: u32) -> Result<Font, HRESULT> {
         let mut font: *mut IDWriteFont = ptr::null_mut();
         unsafe {
             let hr = (*self.native.get()).GetFont(index, &mut font);

--- a/src/font_family.rs
+++ b/src/font_family.rs
@@ -4,7 +4,6 @@
 
 use std::cell::UnsafeCell;
 use std::ptr;
-use winapi::shared::winerror;
 use winapi::um::dwrite::IDWriteLocalizedStrings;
 use winapi::um::dwrite::{IDWriteFont, IDWriteFontCollection, IDWriteFontFamily};
 use wio::com::ComPtr;
@@ -36,7 +35,7 @@ impl FontFamily {
         unsafe {
             let hr = (*self.native.get()).GetFamilyNames(&mut family_names);
             if hr != 0 {
-                return Err(winerror::HRESULT_CODE(hr));
+                return Err(hr);
             }
             Ok(get_locale_string(&mut ComPtr::from_raw(family_names)))
         }
@@ -67,7 +66,7 @@ impl FontFamily {
                 &mut font,
             );
             if hr != 0 {
-                return Err(winerror::HRESULT_CODE(hr));
+                return Err(hr);
             }
             Ok(Font::take(ComPtr::from_raw(font)))
         }
@@ -82,7 +81,7 @@ impl FontFamily {
         unsafe {
             let hr = (*self.native.get()).GetFontCollection(&mut collection);
             if hr != 0 {
-                return Err(winerror::HRESULT_CODE(hr));
+                return Err(hr);
             }
             Ok(FontCollection::take(ComPtr::from_raw(collection)))
         }
@@ -101,7 +100,7 @@ impl FontFamily {
         unsafe {
             let hr = (*self.native.get()).GetFont(index, &mut font);
             if hr != 0 {
-                return Err(winerror::HRESULT_CODE(hr));
+                return Err(hr);
             }
             Ok(Font::take(ComPtr::from_raw(font)))
         }


### PR DESCRIPTION
This closes #61 

Some of the methods in `font_family::FontFamily` can cause a panic. I have added analogous `try_` methods for each which will return a `Result` instead in order to let the caller handle the error.

The next step would be to start migrating callers to use these new methods, e.g.
https://github.com/servo/font-kit/blob/d49041ca57da4e9b412951f96f74cb34e3b6324f/src/sources/directwrite.rs#L44