### PR TITLE
add fallible font methods on Font struct

### DIFF
--- a/src/font.rs
+++ b/src/font.rs
@@ -57,7 +57,7 @@ impl Font {
 
     pub fn to_descriptor(&self) -> FontDescriptor {
         FontDescriptor {
-            family_name: self.get_family_name(),
+            family_name: self.family_name().unwrap_or_default(),
             stretch: self.stretch(),
             style: self.style(),
             weight: self.weight(),
@@ -117,7 +117,7 @@ impl Font {
                 return Err(hr);
             }
 
-            locale_string(&mut ComPtr::from_raw(names))
+            get_locale_string(&mut ComPtr::from_raw(names))
         }
     }
 
@@ -139,7 +139,7 @@ impl Font {
                 return Err(hr);
             }
             if exists == TRUE {
-                Ok(Some(locale_string(&mut ComPtr::from_raw(names))?))
+                Ok(Some(get_locale_string(&mut ComPtr::from_raw(names))?))
             } else {
                 Ok(None)
             }

--- a/src/font.rs
+++ b/src/font.rs
@@ -117,7 +117,7 @@ impl Font {
                 return Err(hr);
             }
 
-            Ok(get_locale_string(&mut ComPtr::from_raw(names)))
+            locale_string(&mut ComPtr::from_raw(names))
         }
     }
 
@@ -139,7 +139,7 @@ impl Font {
                 return Err(hr);
             }
             if exists == TRUE {
-                Ok(Some(get_locale_string(&mut ComPtr::from_raw(names))))
+                Ok(Some(locale_string(&mut ComPtr::from_raw(names))?))
             } else {
                 Ok(None)
             }

--- a/src/font.rs
+++ b/src/font.rs
@@ -57,7 +57,7 @@ impl Font {
 
     pub fn to_descriptor(&self) -> FontDescriptor {
         FontDescriptor {
-            family_name: self.family_name(),
+            family_name: self.get_family_name(),
             stretch: self.stretch(),
             style: self.style(),
             weight: self.weight(),
@@ -87,12 +87,12 @@ impl Font {
         unsafe { mem::transmute::<u32, FontSimulations>((*self.native.get()).GetSimulations()) }
     }
 
-    #[deprecated(note = "Use `try_family_name` instead.")]
-    pub fn family_name(&self) -> String {
-        self.try_family_name().unwrap()
+    #[deprecated(note = "Use `family_name` instead.")]
+    pub fn get_family_name(&self) -> String {
+        self.family_name().unwrap()
     }
 
-    pub fn try_family_name(&self) -> Result<String, HRESULT> {
+    pub fn family_name(&self) -> Result<String, HRESULT> {
         let mut family: *mut IDWriteFontFamily = ptr::null_mut();
         unsafe {
             let hr = (*self.native.get()).GetFontFamily(&mut family);
@@ -104,12 +104,12 @@ impl Font {
         }
     }
 
-    #[deprecated(note = "Use `try_face_name` instead.")]
-    pub fn face_name(&self) -> String {
-        self.try_face_name().unwrap()
+    #[deprecated(note = "Use `face_name` instead.")]
+    pub fn get_face_name(&self) -> String {
+        self.face_name().unwrap()
     }
 
-    pub fn try_face_name(&self) -> Result<String, HRESULT> {
+    pub fn face_name(&self) -> Result<String, HRESULT> {
         let mut names: *mut IDWriteLocalizedStrings = ptr::null_mut();
         unsafe {
             let hr = (*self.native.get()).GetFaceNames(&mut names);
@@ -121,12 +121,12 @@ impl Font {
         }
     }
 
-    #[deprecated(note = "Use `try_informational_string` instead.")]
-    pub fn informational_string(&self, id: InformationalStringId) -> Option<String> {
-        self.try_informational_string(id).unwrap()
+    #[deprecated(note = "Use `informational_string` instead.")]
+    pub fn get_informational_string(&self, id: InformationalStringId) -> Option<String> {
+        self.informational_string(id).unwrap()
     }
 
-    pub fn try_informational_string(
+    pub fn informational_string(
         &self,
         id: InformationalStringId,
     ) -> Result<Option<String>, HRESULT> {
@@ -146,12 +146,12 @@ impl Font {
         }
     }
 
-    #[deprecated(note = "Use `try_create_font_face` instead.")]
-    pub fn create_font_face(&self) -> FontFace {
-        self.try_create_font_face().unwrap()
+    #[deprecated(note = "Use `create_font_face` instead.")]
+    pub fn get_create_font_face(&self) -> FontFace {
+        self.create_font_face().unwrap()
     }
 
-    pub fn try_create_font_face(&self) -> Result<FontFace, HRESULT> {
+    pub fn create_font_face(&self) -> Result<FontFace, HRESULT> {
         let mut face: *mut IDWriteFontFace = ptr::null_mut();
         // FIXME create_font_face should cache the FontFace and return it,
         // there's a 1:1 relationship

--- a/src/font_family.rs
+++ b/src/font_family.rs
@@ -38,7 +38,7 @@ impl FontFamily {
             if hr != 0 {
                 return Err(hr);
             }
-            locale_string(&mut ComPtr::from_raw(family_names))
+            get_locale_string(&mut ComPtr::from_raw(family_names))
         }
     }
 

--- a/src/font_family.rs
+++ b/src/font_family.rs
@@ -38,7 +38,7 @@ impl FontFamily {
             if hr != 0 {
                 return Err(hr);
             }
-            Ok(get_locale_string(&mut ComPtr::from_raw(family_names)))
+            locale_string(&mut ComPtr::from_raw(family_names))
         }
     }
 

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -6,9 +6,10 @@ use std::ffi::OsStr;
 use std::os::windows::ffi::OsStrExt;
 use winapi::ctypes::wchar_t;
 use winapi::shared::minwindef::{BOOL, FALSE};
-use winapi::shared::winerror::S_OK;
+use winapi::shared::winerror::{E_FAIL, S_OK};
 use winapi::um::dwrite::IDWriteLocalizedStrings;
 use winapi::um::winnls::GetUserDefaultLocaleName;
+use winapi::um::winnt::HRESULT;
 use wio::com::ComPtr;
 
 lazy_static! {
@@ -22,7 +23,12 @@ lazy_static! {
     static ref EN_US_LOCALE: Vec<wchar_t> = OsStr::new("en-us").to_wide_null();
 }
 
+#[deprecated(note = "Use `locale_string` instead.")]
 pub fn get_locale_string(strings: &mut ComPtr<IDWriteLocalizedStrings>) -> String {
+    locale_string(strings).unwrap()
+}
+
+pub fn locale_string(strings: &mut ComPtr<IDWriteLocalizedStrings>) -> Result<String, HRESULT> {
     unsafe {
         let mut index: u32 = 0;
         let mut exists: BOOL = FALSE;
@@ -37,14 +43,18 @@ pub fn get_locale_string(strings: &mut ComPtr<IDWriteLocalizedStrings>) -> Strin
 
         let mut length: u32 = 0;
         let hr = strings.GetStringLength(index, &mut length);
-        assert!(hr == 0);
+        if hr != S_OK {
+            return Err(hr);
+        }
 
         let mut name: Vec<wchar_t> = Vec::with_capacity(length as usize + 1);
         let hr = strings.GetString(index, name.as_mut_ptr(), length + 1);
-        assert!(hr == 0);
+        if hr != S_OK {
+            return Err(hr);
+        }
         name.set_len(length as usize);
 
-        String::from_utf16(&name).ok().unwrap()
+        String::from_utf16(&name).map_err(|_| E_FAIL)
     }
 }
 

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -23,12 +23,7 @@ lazy_static! {
     static ref EN_US_LOCALE: Vec<wchar_t> = OsStr::new("en-us").to_wide_null();
 }
 
-#[deprecated(note = "Use `locale_string` instead.")]
-pub fn get_locale_string(strings: &mut ComPtr<IDWriteLocalizedStrings>) -> String {
-    locale_string(strings).unwrap()
-}
-
-pub fn locale_string(strings: &mut ComPtr<IDWriteLocalizedStrings>) -> Result<String, HRESULT> {
+pub fn get_locale_string(strings: &mut ComPtr<IDWriteLocalizedStrings>) -> Result<String, HRESULT> {
     unsafe {
         let mut index: u32 = 0;
         let mut exists: BOOL = FALSE;


### PR DESCRIPTION
Adds more fallible font methods _a. la_ #62 

The naming conventions for this struct were a little different, not have `get_` prefixes. As such, the new names we're as obvious. I added `try_` prefixes but please let me know if there is a better suggestion.