### PR TITLE
Publish 0.11.3.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "dwrote"
 description = "Lightweight binding to DirectWrite."
 repository = "https://github.com/servo/dwrote-rs"
 license = "MPL-2.0"
-version = "0.11.2"
+version = "0.11.3"
 authors = ["The Servo Project Developers", "Vladimir Vukicevic <vladimir@pobox.com>"]
 edition = "2018"
 


### PR DESCRIPTION
This includes the changes from https://github.com/servo/dwrote-rs/pull/62 and #63 which only add new public methods and deprecate existing ones.