### PR TITLE
Expose `IDWriteFontFace::GetSimulations()` through `FontFace::simulations()`

### DIFF
--- a/src/font_face.rs
+++ b/src/font_face.rs
@@ -554,7 +554,9 @@ impl FontFace {
 
     pub fn simulations(&self) -> FontSimulations {
         unsafe {
-            std::mem::transmute::<DWRITE_FONT_SIMULATIONS, FontSimulations>((*self.native.get()).GetSimulations())
+            std::mem::transmute::<DWRITE_FONT_SIMULATIONS, FontSimulations>(
+                (*self.native.get()).GetSimulations(),
+            )
         }
     }
 }

--- a/src/font_face.rs
+++ b/src/font_face.rs
@@ -32,6 +32,7 @@ use super::{DWriteFactory, DefaultDWriteRenderParams, FontFile, FontMetrics};
 use crate::com_helpers::Com;
 use crate::geometry_sink_impl::GeometrySinkImpl;
 use crate::outline_builder::OutlineBuilder;
+use crate::FontSimulations;
 
 pub struct FontFace {
     native: UnsafeCell<ComPtr<IDWriteFontFace>>,
@@ -548,6 +549,12 @@ impl FontFace {
                 }
             }
             None
+        }
+    }
+
+    pub fn simulations(&self) -> FontSimulations {
+        unsafe {
+            std::mem::transmute::<DWRITE_FONT_SIMULATIONS, FontSimulations>((*self.native.get()).GetSimulations())
         }
     }
 }


### PR DESCRIPTION
This would allow the `PlatformFont` for Windows to store one less `bool` in servo.

Related: https://github.com/servo/servo/pull/39633