### PR TITLE
Release version 0.11.5.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "dwrote"
 description = "Lightweight binding to DirectWrite."
 repository = "https://github.com/servo/dwrote-rs"
 license = "MPL-2.0"
-version = "0.11.4"
+version = "0.11.5"
 authors = ["The Servo Project Developers", "Vladimir Vukicevic <vladimir@pobox.com>"]
 edition = "2018"
 


### PR DESCRIPTION
Includes https://github.com/servo/dwrote-rs/pull/70.